### PR TITLE
User requirements files on github actions

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        pip install -r requirements.txt
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ python -m venv ./venv
 
 source ./venv/bin/activate
 
-pip install -r requirements.txt
+pip install -r requirements-dev.txt
 ```
 
 Build the project and install locally

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,1 +1,3 @@
 pytest
+requests
+pywal

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-requests
-pywal
 wheel
+setuptools
+twine


### PR DESCRIPTION
I changed the github actions to consider to use requirements.txt instead of install the dependencies for itself. Just to keep the `requirements.txt` as a source of true about dependencies.