### PR TITLE
Add suppport for non-Ubuntu distros.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ This is pretty light on dependencies, but you will need to make sure you have a 
 * `requests` - python module for HTTP requests.
 * `pywal` - generates color schemes and used for changing the wallpaper.
 
+### Optional Dependencies
+* `feh`, if you use a Linux system that's not Ubuntu or Elementary OS. This is not in PyPi, it'll be in your distros repos.
+
 ## Installation and Usage
 > **NOTE:** For Mac, first test if you have `tkinter` directly installed with your Python version first:
 > ```sh

--- a/backgroundchanger/utils.py
+++ b/backgroundchanger/utils.py
@@ -3,7 +3,7 @@ import logging
 import platform
 from subprocess import Popen, call
 import shutil
-from os import system
+from os import system as run
 import distro
 from tkinter import Tk
 from . import config
@@ -81,7 +81,7 @@ def get_background_cmd(photo_name: str):
                 'picture-uri',
                 'file://' + photo_name
             ]
-        elif not system('feh --help > /dev/null'): # Actually true, 0 (success) is cast to false.
+        elif not run('feh --help > /dev/null'): # Actually true, 0 (success) is cast to false.
             logging.info('Found Feh')
             return [
                 'feh',

--- a/backgroundchanger/utils.py
+++ b/backgroundchanger/utils.py
@@ -81,7 +81,7 @@ def get_background_cmd(photo_name: str):
                 'picture-uri',
                 'file://' + photo_name
             ]
-        elif not os.system('feh --help > /dev/null'): # Actually true, 0 (success) is cast to false.
+        elif not system('feh --help > /dev/null'): # Actually true, 0 (success) is cast to false.
             logging.info('Found Feh')
             return [
                 'feh',

--- a/backgroundchanger/utils.py
+++ b/backgroundchanger/utils.py
@@ -80,6 +80,14 @@ def get_background_cmd(photo_name: str):
                 'picture-uri',
                 'file://' + photo_name
             ]
+        elif not os.system('feh --help > /dev/null'): # Actually true, 0 (success) is cast to false.
+            logging.info('Found Feh')
+            return [
+                'feh',
+                '--bg-scale',
+                photo_name
+            ]
+
     elif system == 'Windows':
         raise ValueError(
             'Windows is not yet implemented to change the background. However, you can still change the background. photo name: {}'.format(

--- a/backgroundchanger/utils.py
+++ b/backgroundchanger/utils.py
@@ -3,6 +3,7 @@ import logging
 import platform
 from subprocess import Popen, call
 import shutil
+from os import system
 import distro
 from tkinter import Tk
 from . import config


### PR DESCRIPTION
This adds support for non-Ubuntu distros by including `feh` as a fallback. Formatted actually worked this time, unlike last.